### PR TITLE
Add 3D example and merge updates

### DIFF
--- a/3d-portfolio/index.html
+++ b/3d-portfolio/index.html
@@ -4,7 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <title>3D Portfolio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/3d-portfolio/src/components/Navbar.tsx
+++ b/3d-portfolio/src/components/Navbar.tsx
@@ -64,6 +64,9 @@ const Navbar = () => {
         <StyledNavLink to="/contact">
           Contact
         </StyledNavLink>
+        <StyledNavLink to="/example">
+          Example
+        </StyledNavLink>
       </NavLinks>
     </NavContainer>
   );

--- a/3d-portfolio/src/index.css
+++ b/3d-portfolio/src/index.css
@@ -1,11 +1,11 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Poppins', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  background-color: #050816;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -24,8 +24,6 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/3d-portfolio/src/pages/Example3D.tsx
+++ b/3d-portfolio/src/pages/Example3D.tsx
@@ -1,0 +1,47 @@
+import { Canvas, useFrame } from '@react-three/fiber'
+import { OrbitControls, Preload } from '@react-three/drei'
+import { styled } from 'styled-components'
+import { useRef, useState } from 'react'
+
+const StyledCanvas = styled(Canvas)`
+  width: 100%;
+  height: 100vh;
+`
+
+function SpinningTorus() {
+  const meshRef = useRef<any>()
+  const [hovered, setHovered] = useState(false)
+
+  useFrame((_, delta) => {
+    if (meshRef.current) {
+      meshRef.current.rotation.x += delta
+      meshRef.current.rotation.y += delta
+    }
+  })
+
+  return (
+    <mesh
+      ref={meshRef}
+      onPointerOver={() => setHovered(true)}
+      onPointerOut={() => setHovered(false)}
+      scale={hovered ? 1.2 : 1}
+    >
+      <torusGeometry args={[1, 0.4, 16, 32]} />
+      <meshStandardMaterial color={hovered ? '#E91E63' : '#2196F3'} />
+    </mesh>
+  )
+}
+
+const Example3D = () => {
+  return (
+    <StyledCanvas camera={{ position: [0, 0, 5], fov: 45 }} shadows>
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[2, 2, 2]} intensity={1} />
+      <SpinningTorus />
+      <OrbitControls />
+      <Preload all />
+    </StyledCanvas>
+  )
+}
+
+export default Example3D

--- a/3d-portfolio/src/pages/LandingPage.tsx
+++ b/3d-portfolio/src/pages/LandingPage.tsx
@@ -1,29 +1,82 @@
-import { Canvas } from '@react-three/fiber'
-import { OrbitControls, Preload } from '@react-three/drei'
+import { Canvas, useFrame } from '@react-three/fiber'
+import { OrbitControls, Preload, Text } from '@react-three/drei'
 import { styled } from 'styled-components'
+import { useRef } from 'react'
+import * as THREE from 'three'
 
 const StyledCanvas = styled(Canvas)`
   width: 100%;
   height: 100vh;
 `
 
+const Overlay = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  pointer-events: none;
+`
+
+const Title = styled.h1`
+  font-size: 4rem;
+  margin: 0;
+  background: linear-gradient(90deg, #ffa500, #8352fd);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+`
+
+const Subtitle = styled.p`
+  font-size: 1.2rem;
+  color: #aaa6c3;
+`
+
+const RotatingTorus = () => {
+  const ref = useRef<THREE.Mesh>(null)
+  useFrame(() => {
+    if (ref.current) {
+      ref.current.rotation.x += 0.005
+      ref.current.rotation.y += 0.01
+    }
+  })
+  return (
+    <mesh ref={ref}>
+      <torusKnotGeometry args={[2, 0.6, 128, 32]} />
+      <meshStandardMaterial color="#8352FD" roughness={0.2} metalness={0.7} />
+    </mesh>
+  )
+}
+
 const LandingPage = () => {
   return (
-    <StyledCanvas
-      shadows
-      camera={{ position: [0, 0, 10], fov: 25 }}
-      gl={{ preserveDrawingBuffer: true }}
-    >
-      <ambientLight intensity={0.5} />
-      <directionalLight position={[0, 0, 5]} intensity={1} />
-      <mesh>
-        <boxGeometry args={[1, 1, 1]} />
-        <meshStandardMaterial color="#8352FD" />
-      </mesh>
-      <OrbitControls enableZoom={false} />
-      <Preload all />
-    </StyledCanvas>
+    <>
+      <Overlay>
+        <Title>Welcome to My Portfolio</Title>
+        <Subtitle>Crafting immersive 3D web experiences</Subtitle>
+      </Overlay>
+      <StyledCanvas
+        shadows
+        camera={{ position: [0, 0, 8], fov: 30 }}
+        gl={{ preserveDrawingBuffer: true }}
+      >
+        <ambientLight intensity={0.6} />
+        <directionalLight position={[0, 0, 5]} intensity={1} />
+        <RotatingTorus />
+        <Text
+          position={[0, -3, 0]}
+          fontSize={0.5}
+          color="#ffffff"
+          anchorX="center"
+          anchorY="middle"
+        >
+          explore
+        </Text>
+        <OrbitControls enableZoom={false} />
+        <Preload all />
+      </StyledCanvas>
+    </>
   )
 }
 
 export default LandingPage 
+

--- a/3d-portfolio/src/router.tsx
+++ b/3d-portfolio/src/router.tsx
@@ -4,6 +4,7 @@ import LandingPage from './pages/LandingPage';
 import AboutMe from './pages/AboutMe';
 import Projects from './pages/Projects';
 import Contact from './pages/Contact';
+import Example3D from './pages/Example3D';
 
 const router = createBrowserRouter([
   {
@@ -25,6 +26,10 @@ const router = createBrowserRouter([
       {
         path: 'contact',
         element: <Contact />
+      },
+      {
+        path: 'example',
+        element: <Example3D />
       }
     ]
   },


### PR DESCRIPTION
## Summary
- merged `main` into `work` to pull latest site updates
- added a new 3D example page with a spinning torus
- wired example page into the router and navbar navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*