### PR TITLE
Fix scroll to use body container

### DIFF
--- a/3d-portfolio/src/App.tsx
+++ b/3d-portfolio/src/App.tsx
@@ -6,7 +6,6 @@ const AppContainer = styled.div`
   width: 100%;
   height: 100%;
   min-height: 100vh;
-  overflow: hidden;
   background-color: #050816;
   color: #ffffff;
 `

--- a/3d-portfolio/src/index.css
+++ b/3d-portfolio/src/index.css
@@ -30,6 +30,7 @@ body {
   margin: 0;
   min-width: 320px;
   min-height: 100vh;
+  scroll-snap-type: y mandatory;
 }
 
 h1 {

--- a/3d-portfolio/src/pages/ScrollPage.tsx
+++ b/3d-portfolio/src/pages/ScrollPage.tsx
@@ -6,10 +6,8 @@ import Example3D from './Example3D'
 import { styled } from 'styled-components'
 
 const ScrollContainer = styled.div`
-  height: 100vh;
-  overflow-y: scroll;
-  scroll-snap-type: y mandatory;
-  scroll-behavior: smooth;
+  display: flex;
+  flex-direction: column;
 `;
 
 const Section = styled.section`


### PR DESCRIPTION
## Summary
- allow body to scroll instead of inner div
- apply scroll snap to body

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run dev` *(fails: vite not found)*
