### PR TITLE
Enhance 3D pages with interactive elements

### DIFF
--- a/3d-portfolio/src/App.css
+++ b/3d-portfolio/src/App.css
@@ -1,14 +1,13 @@
 #root {
-  max-width: 1280px;
   width: 100%;
-  margin: 0 auto;
-  padding: 2rem;
+  margin: 0;
+  padding: 0;
   text-align: center;
 }
 
 @media (max-width: 768px) {
   #root {
-    padding: 1rem;
+    padding: 0;
   }
 }
 

--- a/3d-portfolio/src/index.css
+++ b/3d-portfolio/src/index.css
@@ -17,6 +17,10 @@ html {
   scroll-behavior: smooth;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 a {
   font-weight: 500;
   color: #646cff;
@@ -31,6 +35,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   scroll-snap-type: y mandatory;
+  overflow-x: hidden;
 }
 
 h1 {

--- a/3d-portfolio/src/pages/Example3D.tsx
+++ b/3d-portfolio/src/pages/Example3D.tsx
@@ -1,7 +1,7 @@
 import { Canvas, useFrame } from '@react-three/fiber'
-import { OrbitControls, Preload } from '@react-three/drei'
+import { OrbitControls, Preload, Stars } from '@react-three/drei'
 import { styled } from 'styled-components'
-import { useRef, useMemo } from 'react'
+import { useRef, useMemo, useState } from 'react'
 import * as THREE from 'three'
 
 const StyledCanvas = styled(Canvas)`
@@ -23,6 +23,31 @@ function DodecahedronCage() {
     <mesh ref={meshRef}>
       <dodecahedronGeometry args={[2]} />
       <meshStandardMaterial color="#2196F3" wireframe />
+    </mesh>
+  )
+}
+
+function InteractiveCube() {
+  const meshRef = useRef<THREE.Mesh>(null)
+  const [active, setActive] = useState(false)
+
+  useFrame((_, delta) => {
+    if (meshRef.current) {
+      meshRef.current.rotation.x += delta * 0.5
+      meshRef.current.rotation.y += delta * 0.5
+    }
+  })
+
+  return (
+    <mesh
+      ref={meshRef}
+      position={[0, 0, 0]}
+      onClick={() => setActive(!active)}
+      onPointerOver={() => setActive(true)}
+      onPointerOut={() => setActive(false)}
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color={active ? '#E91E63' : '#2196F3'} />
     </mesh>
   )
 }
@@ -86,10 +111,12 @@ function MovingBalls({ radius = 1.8 }) {
 const Example3D = () => {
   return (
     <StyledCanvas camera={{ position: [0, 0, 5], fov: 45 }} shadows>
+      <Stars radius={5} depth={20} count={2000} factor={4} fade />
       <ambientLight intensity={0.5} />
       <directionalLight position={[2, 2, 2]} intensity={1} />
       <DodecahedronCage />
       <MovingBalls />
+      <InteractiveCube />
       <OrbitControls />
       <Preload all />
     </StyledCanvas>

--- a/3d-portfolio/src/pages/LandingPage.tsx
+++ b/3d-portfolio/src/pages/LandingPage.tsx
@@ -1,5 +1,5 @@
 import { Canvas, useFrame } from '@react-three/fiber'
-import { OrbitControls, Preload, Text } from '@react-three/drei'
+import { OrbitControls, Preload, Text, Stars } from '@react-three/drei'
 import { styled } from 'styled-components'
 import { useRef, useMemo } from 'react'
 import * as THREE from 'three'
@@ -127,6 +127,7 @@ const LandingPage = () => {
         camera={{ position: [0, 0, 8], fov: 30 }}
         gl={{ preserveDrawingBuffer: true }}
       >
+        <Stars radius={5} depth={20} count={2000} factor={4} fade />
         <ambientLight intensity={0.6} />
         <directionalLight position={[0, 0, 5]} intensity={1} />
         <DodecahedronCage />


### PR DESCRIPTION
## Summary
- make main app container responsive
- add global box-sizing and prevent horizontal overflow
- show starfield and interactive cube in Example3D page
- add starfield to LandingPage

## Testing
- `npm install` *(fails: Exit handler never called)*
- `npm run lint` *(fails to load eslint)*